### PR TITLE
Improve Matrix rain animation

### DIFF
--- a/app/src/main/java/com/example/androidcodexone/MatrixView.kt
+++ b/app/src/main/java/com/example/androidcodexone/MatrixView.kt
@@ -15,22 +15,30 @@ class MatrixView @JvmOverloads constructor(
 ) : View(context, attrs) {
 
     private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-
-        color = Color.RED
+        // Typical green color used for the Matrix effect
+        color = Color.rgb(0, 255, 70)
         textSize = 32f * resources.displayMetrics.density
-
         typeface = Typeface.MONOSPACE
     }
 
-    private data class Symbol(var x: Float, var y: Float, var speed: Float)
+    private data class Column(
+        var x: Float,
+        var y: Float,
+        var speed: Float,
+        var length: Int
+    )
 
-    private val symbols = mutableListOf<Symbol>()
-    private val chars = (33..126).map { it.toChar() } // printable ascii
+    private val columns = mutableListOf<Column>()
+
+    // ASCII printable characters combined with Katakana for a more authentic look
+    private val chars: List<Char> =
+        (33..126).map { it.toChar() } + (0x30A0..0x30FF).map { it.toChar() }
+
     private var charHeight = 0f
 
     private val updateRunnable = object : Runnable {
         override fun run() {
-            updateSymbols()
+            updateColumns()
             invalidate()
             postDelayed(this, 50)
         }
@@ -47,33 +55,41 @@ class MatrixView @JvmOverloads constructor(
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        symbols.clear()
+        columns.clear()
         charHeight = paint.fontSpacing
-        val columns = (w / paint.measureText("0")).toInt()
-        for (i in 0 until columns) {
-            val x = i * paint.measureText("0")
-            val y = Random.nextFloat() * h
+        val columnWidth = paint.measureText("0")
+        val count = (w / columnWidth).toInt()
+        for (i in 0 until count) {
+            val x = i * columnWidth + Random.nextFloat() * columnWidth * 0.3f
+            val length = Random.nextInt(5, 20)
+            val y = Random.nextFloat() * h - length * charHeight
             val speed = 5 + Random.nextFloat() * 10
-            symbols.add(Symbol(x, y, speed))
+            columns.add(Column(x, y, speed, length))
         }
     }
 
-    private fun updateSymbols() {
-        val height = height.toFloat()
-        for (symbol in symbols) {
-            symbol.y += symbol.speed
-            if (symbol.y > height) {
-                symbol.y = -charHeight
+    private fun updateColumns() {
+        val viewHeight = height.toFloat()
+        for (column in columns) {
+            column.y += column.speed
+            if (column.y - column.length * charHeight > viewHeight) {
+                column.length = Random.nextInt(5, 20)
+                column.y = -column.length * charHeight
+                column.speed = 5 + Random.nextFloat() * 10
             }
         }
     }
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        for (symbol in symbols) {
-            paint.alpha = Random.nextInt(50, 256)
-            val char = chars.random()
-            canvas.drawText(char.toString(), symbol.x, symbol.y, paint)
+        for (column in columns) {
+            for (i in 0 until column.length) {
+                val yPos = column.y - i * charHeight
+                if (yPos < -charHeight || yPos > height + charHeight) continue
+                paint.alpha = Random.nextInt(50, 256)
+                val char = chars.random()
+                canvas.drawText(char.toString(), column.x, yPos, paint)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- make MatrixView use vertical streams instead of independent characters
- add Japanese katakana to the character set
- randomly vary column positions and lengths
- animate columns falling continuously

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685fc173edf0832da2d843396a0c8734