### PR TITLE
Add Picasso image loading example

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation("com.squareup.picasso:picasso:2.8")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".MatrixActivity" />
+        <activity android:name=".PicassoActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/androidcodexone/MainActivity.kt
+++ b/app/src/main/java/com/example/androidcodexone/MainActivity.kt
@@ -22,5 +22,9 @@ class MainActivity : AppCompatActivity() {
         findViewById<Button>(R.id.btn_matrix).setOnClickListener {
             startActivity(Intent(this, MatrixActivity::class.java))
         }
+
+        findViewById<Button>(R.id.btn_picasso).setOnClickListener {
+            startActivity(Intent(this, PicassoActivity::class.java))
+        }
     }
 }

--- a/app/src/main/java/com/example/androidcodexone/PicassoActivity.kt
+++ b/app/src/main/java/com/example/androidcodexone/PicassoActivity.kt
@@ -1,0 +1,19 @@
+package com.example.androidcodexone
+
+import android.os.Bundle
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import com.squareup.picasso.Picasso
+
+class PicassoActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_picasso)
+
+        val imageView: ImageView = findViewById(R.id.image_view)
+        Picasso.get()
+            .load("https://via.placeholder.com/300.png")
+            .into(imageView)
+    }
+}
+

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,6 +24,16 @@
         app:layout_constraintTop_toBottomOf="@id/hello_text"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/btn_picasso" />
+
+    <Button
+        android:id="@+id/btn_picasso"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/open_image"
+        app:layout_constraintTop_toBottomOf="@id/btn_matrix"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_picasso.xml
+++ b/app/src/main/res/layout/activity_picasso.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/image_view"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">AndroidCodexOne</string>
     <string name="open_matrix">Open Matrix</string>
+    <string name="open_image">Open Image</string>
 </resources>


### PR DESCRIPTION
## Summary
- add Picasso library dependency
- create `PicassoActivity` that loads an image
- add layout for the new activity
- add button in `MainActivity` and layout to launch new activity
- add corresponding string resource and manifest entry

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685fe00759fc832dbb0d92b69779e7a5